### PR TITLE
Add API: yoink#isSwapping() 

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,12 @@ Just pass a count to the `[y` command.  For example, to rotate to yank #12 as di
 
 You can call `yoink#manualYank` for this.  Note that calling this will also set the contents of the default register with the given value.  If you just want to add to history without affecting the default register, you can call `yoink#addTextToHistory` instead
 
+* #### I want to use Yoink `<c-p>` mapping in conjunction with the default `ctrlp.vim` mapping
+
+Just use the following mappings:
+
+```viml
+let g:ctrlp_map=''
+nmap <expr> <c-p> yoink#isSwapping() ? '<plug>(YoinkPostPasteSwapForward)' : '<Plug>(ctrlp)'
+```
+

--- a/autoload/yoink.vim
+++ b/autoload/yoink.vim
@@ -387,6 +387,10 @@ function! yoink#getYankInfoForReg(reg)
     return { 'text': getreg(a:reg), 'type': getregtype(a:reg) }
 endfunction
 
+function! yoink#isSwapping()
+    return s:isSwapping
+endfunction
+
 function! yoink#showYanks()
     echohl WarningMsg | echo "--- Yanks ---" | echohl None
     let i = 0

--- a/doc/yoink.txt
+++ b/doc/yoink.txt
@@ -99,4 +99,11 @@ Just pass a count to the '[y' command.  For example, to rotate to yank #12 as di
 
 You can call 'yoink#manualYank' for this.  Note that calling this will also set the contents of the default register with the given value.  If you just want to add to history without affecting the default register, you can call 'yoink#addTextToHistory' instead
 
+- 'I want to use Yoink `<c-p>` mapping in conjunction with the default `ctrlp.vim` mapping'
+
+Just use the following mappings:
+
+    let g:ctrlp_map=''
+    nmap <expr> <c-p> yoink#isSwapping() ? '<plug>(YoinkPostPasteSwapForward)' : '<Plug>(ctrlp)'
+
  vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
This api provides more flexible mapping using `<expr>`
Especially for customizing `YoinkPostPasteSwap..` feature

Example:
 ```viml
" CtrlP mapping
let g:ctrlp_map=''
nmap <expr> <c-p> yoink#isSwapping() ? '<plug>(YoinkPostPasteSwapForward)' : '<Plug>(ctrlp)'
```

With above mappings,  type `<c-p>` to swap the recent paste when `yoink` is active, and 
leave the `<c-p>` mapping for other plug-ins when `yoink` isn't active.