### PR TITLE
Change YoinkPaste_p and YoinkPaste_P mappings

### DIFF
--- a/plugin/yoink.vim
+++ b/plugin/yoink.vim
@@ -34,8 +34,8 @@ nnoremap <silent> <plug>(YoinkPostPasteSwapForward) :<c-u>call yoink#postPasteSw
 nnoremap <silent> <plug>(YoinkPostPasteSwapBack) :<c-u>call yoink#postPasteSwap(1)<cr>
 
 " We use opfunc here to make it work correctly with repeat `.` operation
-nnoremap <silent> <plug>(YoinkPaste_p) :<c-u>call yoink#setupPaste('p', v:register, v:count)<cr>:set opfunc=yoink#paste<cr>g@l
-nnoremap <silent> <plug>(YoinkPaste_P) :<c-u>call yoink#setupPaste('P', v:register, v:count)<cr>:set opfunc=yoink#paste<cr>g@l
+nnoremap <silent> <plug>(YoinkPaste_p) :<c-u>execute('call yoink#setupPaste("p", v:register, v:count) \| set opfunc=yoink#paste \| normal! g@l')<CR>
+nnoremap <silent> <plug>(YoinkPaste_P) :<c-u>execute('call yoink#setupPaste("P", v:register, v:count) \| set opfunc=yoink#paste \| normal! g@l')<CR>
 
 nnoremap <silent> <plug>(YoinkPostPasteToggleFormat) :<c-u>call yoink#postPasteToggleFormat()<cr>
 


### PR DESCRIPTION
The previous commands did not work properly in some cases, like if you
are in Insert mode, and then press `<c-o>` to enter Normal mode temporarily,
then only the yoink#setupPaste part actually ran and the remaining of the command got
entered in the buffer (since that mode allows us to enter ONE command only)
I had also seen this behaviour in macro-recording mode.

The new mappings run the commands all in one go using the execute()
function, so the previous artifacts are now avoided.